### PR TITLE
VSDEV-4977_change-final-stage-image

### DIFF
--- a/todo-app/backend/Dockerfile
+++ b/todo-app/backend/Dockerfile
@@ -7,7 +7,7 @@ COPY . .
 RUN go build -o /go-server
 
 # final stage
-FROM alpine
+FROM golang:1.20-alpine AS runner
 WORKDIR /
 COPY --from=build /go-server /go-server
 EXPOSE 8888


### PR DESCRIPTION
When building a container using buildkit-rootless, the container cannot be built. It seems that the Go application fails the multi-stage build (but succeeds in the single-stage build).

ref. https://github.com/moby/buildkit/issues/4265